### PR TITLE
✨ `Journal`: Save `Entry#summary` when Writing `Entries`

### DIFF
--- a/app/furniture/journal/entries/_form.html.erb
+++ b/app/furniture/journal/entries/_form.html.erb
@@ -1,5 +1,7 @@
 <%= form_with model: entry.location, class: "flex flex-col grow" do |f| %>
     <%= render "text_field", { attribute: :headline, form: f} %>
+    <%= render "text_area", { attribute: :summary, form: f} %>
+
     <%= render "text_area", { attribute: :body, form: f, field_classes: "grow", container_classes: "grow flex flex-col"} %>
     <%= render "datetime_field", { attribute: :published_at, form: f} %>
 

--- a/app/furniture/journal/entry_policy.rb
+++ b/app/furniture/journal/entry_policy.rb
@@ -17,7 +17,7 @@ class Journal
     end
 
     def permitted_attributes(_params)
-      %i[headline body published_at]
+      %i[headline summary body published_at]
     end
 
     class Scope < ApplicationScope


### PR DESCRIPTION
- https://github.com/zinc-collective/convene-journal/issues/2
- https://github.com/zinc-collective/convene-journal/issues/10

And just like that, there's a `Summary` field on the `Journal::Entry#new` page!


### After
<img width="432" alt="Screenshot 2024-01-28 at 9 01 16 PM" src="https://github.com/zinc-collective/convene-journal/assets/50284/483cfc01-80f1-4536-86e0-134fe7f2562a">

### Before
<img width="437" alt="Screenshot 2024-01-28 at 9 06 00 PM" src="https://github.com/zinc-collective/convene-journal/assets/50284/493629ef-36f4-4dd8-ad8c-c159b01422f3">

