### PR TITLE
Add RSS feed for journal entries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "rswag-ui"
 #
 # Allows us to render .markdown.erb files
 gem "redcarpet", "~> 3.6"
+# RSS feed generation
+gem "rss", "~> 0.3"
 # Breadcrumbs!
 gem "gretel", "~> 5.0"
 # Better UI components

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,8 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rss (0.3.2)
+      rexml
     rswag-api (2.13.0)
       activesupport (>= 3.1, < 7.2)
       railties (>= 3.1, < 7.2)
@@ -577,6 +579,7 @@ DEPENDENCIES
   rotp (~> 6.3)
   rqrcode (~> 2.2)
   rspec-rails (~> 6.1.1)
+  rss (~> 0.3)
   rswag-api
   rswag-specs
   rswag-ui

--- a/app/furniture/journal/entries/index.html.erb
+++ b/app/furniture/journal/entries/index.html.erb
@@ -1,3 +1,10 @@
 <%- breadcrumb :journal_entries, journal %>
+<%- content_for :head do %>
+  <%= auto_discovery_link_tag(
+    :rss,
+    polymorphic_path(journal.location(child: :entries), format: :rss),
+    title: "#{journal.room.name} Journal"
+  ) %>
+<%- end %>
 
 <%= render journal %>

--- a/app/furniture/journal/entries_controller.rb
+++ b/app/furniture/journal/entries_controller.rb
@@ -41,6 +41,12 @@ class Journal::EntriesController < FurnitureController
   end
 
   def index
+    respond_to do |format|
+      format.html
+      format.rss do
+        render body: rss_feed.to_xml, content_type: Mime[:rss]
+      end
+    end
   end
 
   helper_method def page_title
@@ -53,5 +59,20 @@ class Journal::EntriesController < FurnitureController
 
   helper_method def journal
     Journal::Journal.find_by(id: params[:journal_id])
+  end
+
+  private
+
+  def rss_feed
+    Journal::RssFeed.new(
+      journal: journal,
+      entries: rss_entries,
+      feed_url: polymorphic_url(journal.location(child: :entries), format: :rss),
+      entry_url: ->(entry) { polymorphic_url(entry.location) }
+    )
+  end
+
+  def rss_entries
+    policy_scope(journal.entries.recent).limit(10)
   end
 end

--- a/app/furniture/journal/rss_feed.rb
+++ b/app/furniture/journal/rss_feed.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rss/maker"
+
+class Journal
+  class RssFeed
+    def initialize(journal:, entries:, feed_url:, entry_url:)
+      @journal = journal
+      @entries = entries
+      @feed_url = feed_url
+      @entry_url = entry_url
+    end
+
+    def to_xml
+      RSS::Maker.make("2.0") do |feed|
+        feed.channel.title = title
+        feed.channel.link = feed_url
+        feed.channel.description = description
+
+        entries.each do |entry|
+          feed.items.new_item do |item|
+            item.title = entry.headline
+            item.link = entry_url.call(entry)
+            item.description = entry_description(entry)
+            item.pubDate = entry.published_at || entry.updated_at
+            item.guid.content = item.link
+            item.guid.isPermaLink = true
+          end
+        end
+      end.to_s
+    end
+
+    private
+
+    attr_reader :journal, :entries, :feed_url, :entry_url
+
+    def title
+      "#{journal.room.name} Journal"
+    end
+
+    def description
+      "Recent entries from #{journal.room.name}"
+    end
+
+    def entry_description(entry)
+      entry.summary.to_s.empty? ? entry.body : entry.summary
+    end
+  end
+end

--- a/app/furniture/journal/rss_feed.rb
+++ b/app/furniture/journal/rss_feed.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rss/maker"
+require "time"
 
 class Journal
   class RssFeed
@@ -22,7 +23,7 @@ class Journal
             item.title = entry.headline
             item.link = entry_url.call(entry)
             item.description = entry_description(entry)
-            item.pubDate = entry.published_at || entry.updated_at
+            item.pubDate = rss_time(entry.published_at || entry.updated_at)
             item.guid.content = item.link
             item.guid.isPermaLink = true
           end
@@ -44,6 +45,10 @@ class Journal
 
     def entry_description(entry)
       entry.summary.to_s.empty? ? entry.body : entry.summary
+    end
+
+    def rss_time(value)
+      value&.to_time
     end
   end
 end

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -14,6 +14,7 @@
     <%= tag :meta, name: :description, content: current_room.description %>
   <%- end %>
 
+  <%= content_for(:head) if content_for?(:head) %>
 
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/spec/furniture/journal/entries_controller_request_spec.rb
+++ b/spec/furniture/journal/entries_controller_request_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 require "cgi"
+require "rss"
 
 RSpec.describe Journal::EntriesController, type: :request do
   let(:journal) { create(:journal) }
@@ -7,7 +8,7 @@ RSpec.describe Journal::EntriesController, type: :request do
   let(:room) { journal.room }
   let(:member) { create(:person, spaces: [space]) }
 
-  before { sign_in(space, member) }
+  before { sign_in(space, member) if member.present? }
 
   describe "#index" do
     subject(:perform_request) do
@@ -27,6 +28,40 @@ RSpec.describe Journal::EntriesController, type: :request do
 
       it { is_expected.to include(CGI.escapeHTML(published_entry.headline)) }
       it { is_expected.to include(CGI.escapeHTML(unpublished_entry.headline)) }
+      it { is_expected.to include("application/rss+xml") }
+      it { is_expected.to include(polymorphic_path(journal.location(child: :entries), format: :rss)) }
+    end
+
+    context "when requesting RSS" do
+      subject(:feed) { RSS::Parser.parse(response.body, false) }
+
+      let(:member) { nil }
+      let!(:unpublished_entry) do
+        create(:journal_entry, journal: journal, headline: "Draft entry", published_at: nil)
+      end
+
+      let!(:published_entries) do
+        11.times.map do |index|
+          create(:journal_entry,
+            journal: journal,
+            headline: "Published entry #{index}",
+            body: "Body #{index}",
+            summary: "Summary #{index}",
+            published_at: (index + 1).hours.ago)
+        end
+      end
+
+      before do
+        get polymorphic_path(journal.location(child: :entries)), headers: {"ACCEPT" => "application/rss+xml"}
+      end
+
+      it "responds with the latest 10 visible journal entries" do
+        expect(test_response).to be_media_type(:rss)
+        expect(feed.channel.title).to eq("#{room.name} Journal")
+        expect(feed.items.map(&:title)).to eq(published_entries.first(10).map(&:headline))
+        expect(feed.items.map(&:description)).to eq(published_entries.first(10).map(&:summary))
+        expect(feed.items.map(&:title)).not_to include(unpublished_entry.headline)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- adds an RSS 2.0 feed for Journal entries at the entries index with `.rss` / `Accept: application/rss+xml` support
- limits feed output to the 10 most recent entries visible to the requester
- adds RSS autodiscovery metadata to the journal entries page
- adds request coverage for the feed link, RSS response, item limit, and draft exclusion for guests

## Verification
- `ruby -c app/furniture/journal/rss_feed.rb`
- `ruby -c app/furniture/journal/entries_controller.rb`
- `ruby -c spec/furniture/journal/entries_controller_request_spec.rb`
- `git diff --check`

I could not run the full request spec locally because this machine only has macOS Ruby 2.6.10 available, while the project requires Ruby 3.2.3 / Bundler 2.4.12.

Addresses #19. If the old bounty linked from the issue is still active, please let me know what payment details you need after review/merge.